### PR TITLE
Refactor submission handling and updated discord.py to 2.6.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-discord.py==2.5.2
+discord.py==2.6.4
 python-dotenv
 requests

--- a/silliana.py
+++ b/silliana.py
@@ -40,6 +40,9 @@ async def on_ready():
     # Add persistent views
     from cogs.forms import SubmissionButton
     bot.add_view(SubmissionButton())
+    from cogs.forms import SubmissionReviewButtons, PostedButton
+    bot.add_view(SubmissionReviewButtons())
+    bot.add_view(PostedButton())
 
     # Sync slash commands automatically
     try:


### PR DESCRIPTION
 i made some changes to how the queue works, when a submission decision has been made the whole embed deletes and the decision still moves to either the approved denied etc channels. it should make the queue cleaner. i also fixed the issue with the buttons not working after restart. (this is kinda why i needed to delete the embeds after choice is made)